### PR TITLE
Add campaign selection and progress tracking

### DIFF
--- a/src/miner.py
+++ b/src/miner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 import aiohttp
 
@@ -46,9 +46,65 @@ async def _discover_campaign(session: aiohttp.ClientSession) -> Dict[str, Any]:
     # минимальный дашборд дропсов для текущего пользователя
     return await _gql(session, "ViewerDropsDashboard", {"isLoggedIn": True})
 
-async def run_account(login: str, proxy: Optional[str], queue, stop_evt: asyncio.Event):
+def _extract_campaigns(drops: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Извлекаем список кампаний из ответа Twitch."""
+    campaigns: List[Dict[str, str]] = []
+    lst: List[Dict[str, Any]] = []
+    if isinstance(drops.get("currentCampaigns"), list):
+        lst = drops["currentCampaigns"]
+    elif isinstance(drops.get("availableCampaigns"), list):
+        lst = drops["availableCampaigns"]
+    elif isinstance(drops.get("campaigns"), list):
+        lst = drops["campaigns"]
+
+    for c in lst:
+        game = c.get("game") or c.get("gameTitle") or {}
+        campaigns.append({
+            "id": c.get("id", ""),
+            "name": c.get("name") or c.get("displayName") or c.get("id", ""),
+            "game": game.get("name") or game.get("displayName") or "",
+        })
+    return campaigns
+
+def _find_campaign(drops: Dict[str, Any], cid: str) -> Optional[Dict[str, Any]]:
+    """Возвращает объект кампании по ID."""
+    for key in ("currentCampaigns", "availableCampaigns", "campaigns"):
+        lst = drops.get(key)
+        if isinstance(lst, list):
+            for c in lst:
+                if c.get("id") == cid:
+                    return c
+    return None
+
+def _campaign_progress(camp: Dict[str, Any]) -> tuple[float, int]:
+    """Пытаемся вычислить прогресс кампании в минутах."""
+    drops = camp.get("timeBasedDrops") or camp.get("timebasedDrops") or camp.get("drops") or []
+    for d in drops:
+        cur = (
+            (d.get("self") or {}).get("currentMinutesWatched")
+            or d.get("currentMinutesWatched")
+            or 0
+        )
+        req = (
+            (d.get("self") or {}).get("requiredMinutesWatched")
+            or d.get("requiredMinutesWatched")
+            or 0
+        )
+        if req:
+            pct = min(cur / req, 1.0) * 100.0
+            remain = max(req - cur, 0)
+            return pct, int(remain)
+    return 0.0, 0
+
+async def run_account(
+    login: str,
+    proxy: Optional[str],
+    queue,
+    stop_evt: asyncio.Event,
+    campaign_id: Optional[str] = None,
+):
     """
-    Шаг 2a: без видео. Только GQL-дискавери кампаний для аккаунта.
+    Шаг 2a: без видео. GQL-дискавери кампаний для аккаунта и трекинг прогресса.
     - читает cookies/<login>.json -> auth-token
     - вызывает ViewerDropsDashboard PQ
     - обновляет GUI: Status/Campaign/Game
@@ -72,48 +128,67 @@ async def run_account(login: str, proxy: Optional[str], queue, stop_evt: asyncio
         try:
             data = await _discover_campaign(session)
 
-            # Вытаскиваем “как получится” имя кампании и игры (структура у Twitch часто меняется)
-            camp_name = ""
-            game_name = ""
+            # Вытаскиваем список кампаний
+            camp_list: List[Dict[str, str]] = []
             try:
                 d = (data or {}).get("data") or {}
                 vd = d.get("viewer") or d.get("currentUser") or {}
                 drops = vd.get("dropsDashboard") or vd.get("drops") or vd
-
                 if isinstance(drops, dict):
-                    # сначала пробуем текущую/активные кампании
-                    campaigns = []
-                    if isinstance(drops.get("currentCampaigns"), list):
-                        campaigns = drops["currentCampaigns"]
-                    elif isinstance(drops.get("availableCampaigns"), list):
-                        campaigns = drops["availableCampaigns"]
-                    elif isinstance(drops.get("campaigns"), list):
-                        campaigns = drops["campaigns"]
-
-                    if campaigns:
-                        c0 = campaigns[0]
-                        camp_name = c0.get("name") or c0.get("displayName") or c0.get("id","")
-                        game = c0.get("game") or c0.get("gameTitle") or {}
-                        game_name = (game.get("name") or game.get("displayName") or "")
-                # fallback — по тексту
-                if not camp_name:
-                    import re, json as _json
-                    txt = _json.dumps(drops)
-                    m = re.search(r'"displayName"\s*:\s*"([^"]+)"', txt) or re.search(r'"name"\s*:\s*"([^"]+)"', txt)
-                    if m: camp_name = m.group(1)
-                    m2 = re.search(r'"gameTitle"\s*:\s*{[^}]*"displayName"\s*:\s*"([^"]+)"', txt) or re.search(r'"game"\s*:\s*{[^}]*"name"\s*:\s*"([^"]+)"', txt)
-                    if m2: game_name = m2.group(1)
+                    camp_list = _extract_campaigns(drops)
+                await queue.put(
+                    (login, "campaigns", {"list": [(c["id"], c["name"]) for c in camp_list]})
+                )
             except Exception:
                 pass
 
-            await queue.put((login, "campaign", {"camp": camp_name or "—", "game": game_name or "—"}))
-            await queue.put((login, "status", {"status": "Ready", "note": "Campaigns discovered"}))
+            if campaign_id:
+                # найдём выбранную кампанию
+                selected = None
+                for c in camp_list:
+                    if c["id"] == campaign_id:
+                        selected = c
+                        break
+                if not selected and camp_list:
+                    selected = camp_list[0]
+                    campaign_id = selected["id"]
+                if selected:
+                    await queue.put(
+                        (
+                            login,
+                            "campaign",
+                            {
+                                "id": campaign_id,
+                                "camp": selected["name"],
+                                "game": selected["game"],
+                            },
+                        )
+                    )
+                await queue.put(
+                    (login, "status", {"status": "Running", "note": "Tracking campaign"})
+                )
+                # цикл обновления прогресса
+                while not stop_evt.is_set():
+                    try:
+                        data = await _discover_campaign(session)
+                        d = (data or {}).get("data") or {}
+                        vd = d.get("viewer") or d.get("currentUser") or {}
+                        drops = vd.get("dropsDashboard") or vd.get("drops") or vd
+                        camp_obj = _find_campaign(drops, campaign_id)
+                        if camp_obj:
+                            pct, remain = _campaign_progress(camp_obj)
+                            await queue.put(
+                                (login, "progress", {"pct": pct, "remain": remain})
+                            )
+                    except Exception:
+                        pass
+                    await asyncio.sleep(30.0)
 
-            # Пока просто ждём Stop (заготовка под 2b: heartbeats/прогресс)
-            while not stop_evt.is_set():
-                await asyncio.sleep(1.0)
-
-            await queue.put((login, "status", {"status": "Stopped"}))
+                await queue.put((login, "status", {"status": "Stopped"}))
+            else:
+                await queue.put(
+                    (login, "status", {"status": "Ready", "note": "Campaigns discovered"})
+                )
 
         except Exception as e:
             await queue.put((login, "error", {"msg": f"GQL error: {e}"}))

--- a/src/types.py
+++ b/src/types.py
@@ -11,6 +11,9 @@ class Account:
     totp_secret: str = ""
     status: str = "Idle"
     note: str = ""
+    # ID выбранной кампании (для GQL-трекера)
+    campaign_id: str = ""
+    # Человеко-понятное имя активной кампании
     active_campaign: str = ""
     game: str = ""
     progress_pct: float = 0.0


### PR DESCRIPTION
## Summary
- expose full campaign list and progress tracking in `miner.run_account`
- add campaign selection dropdown to GUI and pass selected campaign ID
- track and display progress updates per campaign

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689ebc38883c8323adf9a69b350ef220