### PR TITLE
Remove semicolon-separated statements

### DIFF
--- a/src/accounts.py
+++ b/src/accounts.py
@@ -4,7 +4,8 @@ from typing import List, Optional
 import csv, json
 from .types import Account
 
-COOKIES_DIR = Path("cookies"); COOKIES_DIR.mkdir(exist_ok=True)
+COOKIES_DIR = Path("cookies")
+COOKIES_DIR.mkdir(exist_ok=True)
 
 def _parse_txt(path: Path) -> list[Account]:
     res: list[Account] = []

--- a/src/gui.py
+++ b/src/gui.py
@@ -34,16 +34,29 @@ class MainWindow(QMainWindow):
         self.metrics = {"claimed": 0, "errors": 0}
 
         # ── UI ──────────────────────────────────────────────────────────────────
-        root = QWidget(); self.setCentralWidget(root)
+        root = QWidget()
+        self.setCentralWidget(root)
         v = QVBoxLayout(root)
 
         top = QHBoxLayout()
-        self.lbl = QLabel("—"); top.addWidget(self.lbl); top.addStretch(1)
-        self.btn_check = QPushButton("Проверить GQL"); self.btn_check.clicked.connect(self.check_gql); top.addWidget(self.btn_check)
-        self.btn_onb = QPushButton("Onboarding (Playwright)"); self.btn_onb.clicked.connect(self.onboarding); top.addWidget(self.btn_onb)
-        self.btn_onb2 = QPushButton("Onboarding (WebView)"); self.btn_onb2.clicked.connect(self.onboarding_webview); top.addWidget(self.btn_onb2)
-        self.btn_start = QPushButton("Start All"); self.btn_start.clicked.connect(self.start_all); top.addWidget(self.btn_start)
-        self.btn_stop = QPushButton("Stop All"); self.btn_stop.clicked.connect(self.stop_all); top.addWidget(self.btn_stop)
+        self.lbl = QLabel("—")
+        top.addWidget(self.lbl)
+        top.addStretch(1)
+        self.btn_check = QPushButton("Проверить GQL")
+        self.btn_check.clicked.connect(self.check_gql)
+        top.addWidget(self.btn_check)
+        self.btn_onb = QPushButton("Onboarding (Playwright)")
+        self.btn_onb.clicked.connect(self.onboarding)
+        top.addWidget(self.btn_onb)
+        self.btn_onb2 = QPushButton("Onboarding (WebView)")
+        self.btn_onb2.clicked.connect(self.onboarding_webview)
+        top.addWidget(self.btn_onb2)
+        self.btn_start = QPushButton("Start All")
+        self.btn_start.clicked.connect(self.start_all)
+        top.addWidget(self.btn_start)
+        self.btn_stop = QPushButton("Stop All")
+        self.btn_stop.clicked.connect(self.stop_all)
+        top.addWidget(self.btn_stop)
         v.addLayout(top)
 
         self.tbl = QTableWidget(0, 8)
@@ -51,9 +64,12 @@ class MainWindow(QMainWindow):
         self.tbl.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         v.addWidget(self.tbl)
 
-        self.log = QTextEdit(); self.log.setReadOnly(True); v.addWidget(self.log)
+        self.log = QTextEdit()
+        self.log.setReadOnly(True)
+        v.addWidget(self.log)
 
-        self.populate(); self.refresh_totals()
+        self.populate()
+        self.refresh_totals()
 
         # ── встроенный asyncio-loop ─────────────────────────────────────────────
         # ВАЖНО: loop живёт в главном потоке; QTimer "тикает" его, чтобы шли задачи.
@@ -64,14 +80,17 @@ class MainWindow(QMainWindow):
         self._feeder_task = self.loop.create_task(self.feeder())
 
         # таймер вызывает короткий прогон цикла, чтобы не блокировать Qt
-        self.timer = QTimer(self); self.timer.setInterval(50)  # 20 FPS малой кровью
-        self.timer.timeout.connect(self.pump); self.timer.start()
+        self.timer = QTimer(self)
+        self.timer.setInterval(50)  # 20 FPS малой кровью
+        self.timer.timeout.connect(self.pump)
+        self.timer.start()
 
     # ── helpers ────────────────────────────────────────────────────────────────
     def populate(self):
         self.tbl.setRowCount(0)
         for a in self.accounts:
-            r = self.tbl.rowCount(); self.tbl.insertRow(r)
+            r = self.tbl.rowCount()
+            self.tbl.insertRow(r)
             for i, val in enumerate([a.label, a.login, a.status, "", "", "0%", "0", ""]):
                 self.tbl.setItem(r, i, QTableWidgetItem(str(val)))
 
@@ -105,7 +124,8 @@ class MainWindow(QMainWindow):
             if not cookie_file.exists():
                 self.tbl.item(r,2).setText("NO COOKIES")
                 self.log_line(f"[{login}] NO COOKIES — {cookie_file} not found")
-                miss += 1; continue
+                miss += 1
+                continue
 
             token = ""
             try:
@@ -117,12 +137,14 @@ class MainWindow(QMainWindow):
             except Exception as e:
                 self.tbl.item(r,2).setText("BAD COOKIES")
                 self.log_line(f"[{login}] BAD COOKIES — {e}")
-                other += 1; continue
+                other += 1
+                continue
 
             if not token:
                 self.tbl.item(r,2).setText("NO TOKEN")
                 self.log_line(f"[{login}] NO TOKEN in cookies")
-                miss += 1; continue
+                miss += 1
+                continue
 
             try:
                 resp = requests.get(

--- a/src/main.py
+++ b/src/main.py
@@ -6,15 +6,20 @@ from PySide6.QtWidgets import QApplication
 from .gui import MainWindow
 
 def create_sample_txt(path: Path):
-    if path.exists(): print(f"{path} уже существует"); return
+    if path.exists():
+        print(f"{path} уже существует")
+        return
     path.write_text("user1:pass1\nuser2:pass2\n", encoding="utf-8")
     print(f"Создан пример TXT: {path}")
 
 def create_sample_csv(path: Path):
-    if path.exists(): print(f"{path} уже существует"); return
+    if path.exists():
+        print(f"{path} уже существует")
+        return
     with path.open("w", encoding="utf-8", newline="") as f:
         w = csv.DictWriter(f, fieldnames=["label","login","password","proxy","totp_secret"])
-        w.writeheader(); w.writerow({"label":"acc001","login":"user1","password":"pass1","proxy":"","totp_secret":""})
+        w.writeheader()
+        w.writerow({"label":"acc001","login":"user1","password":"pass1","proxy":"","totp_secret":""})
     print(f"Создан пример CSV: {path}")
 
 def main():
@@ -25,18 +30,27 @@ def main():
     p.add_argument("--onboarding", action="store_true", help="Открыть логин-окна и сохранить cookies/<login>.json")
     args = p.parse_args()
 
-    if args.create_sample_txt: create_sample_txt(Path("accounts.txt")); return
-    if args.create_sample_csv: create_sample_csv(Path("accounts.csv")); return
-    if not args.accounts: print("Укажите --accounts путь (CSV или TXT)"); sys.exit(2)
+    if args.create_sample_txt:
+        create_sample_txt(Path("accounts.txt"))
+        return
+    if args.create_sample_csv:
+        create_sample_csv(Path("accounts.csv"))
+        return
+    if not args.accounts:
+        print("Укажите --accounts путь (CSV или TXT)")
+        sys.exit(2)
 
     app = QApplication(sys.argv)
     win = MainWindow(Path(args.accounts))
     win.show()
 
     # asyncio + Qt pump
-    loop = asyncio.new_event_loop(); asyncio.set_event_loop(loop)
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     from PySide6.QtCore import QTimer
-    t = QTimer(); t.timeout.connect(lambda: None); t.start(50)
+    t = QTimer()
+    t.timeout.connect(lambda: None)
+    t.start(50)
     sys.exit(app.exec())
 
 if __name__ == "__main__":

--- a/src/onboarding.py
+++ b/src/onboarding.py
@@ -182,7 +182,8 @@ def _remove_from_accounts_file(accounts_file: Path, login: str) -> bool:
             raw = line.rstrip("\r\n")
             s = raw.strip()
             if not s:
-                out.append(raw); continue
+                out.append(raw)
+                continue
             # "login:pass" (твоя схема) — самое надёжное
             if s.startswith(f"{login}:"):
                 removed = True
@@ -217,13 +218,15 @@ def bulk_onboarding(
       - EMAIL_2FA_REQUIRED → SKIP
       - USERNAME_NOT_FOUND → DELETE и удаляем из accounts.txt (если указан путь)
     """
-    out_dir = Path(out_dir); out_dir.mkdir(parents=True, exist_ok=True)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
     results: List[Dict[str, str]] = []
 
     with sync_playwright() as p:
         browser = _launch_browser(p)
         context = browser.new_context(viewport={"width": 1280, "height": 900})
-        page = context.new_page(); page.bring_to_front()
+        page = context.new_page()
+        page.bring_to_front()
 
         for login, password, totp in accounts:
             progress_cb and progress_cb({"login": login, "result": "STEP", "note": "Открываю форму логина"})
@@ -258,14 +261,16 @@ def bulk_onboarding(
                     out_path = out_dir / f"{login}.json"
                     out_path.write_text(json.dumps(context.cookies(), indent=2, ensure_ascii=False), encoding="utf-8")
                     res = {"login": login, "result": "OK", "note": f"cookies → {out_path}"}
-                    results.append(res); progress_cb and progress_cb(res)
+                    results.append(res)
+                    progress_cb and progress_cb(res)
                     saved = True
                     break
 
                 # особые кейсы — чтобы не виснуть
                 if _email_challenge_present(page):
                     res = {"login": login, "result": "SKIP", "note": "EMAIL_2FA_REQUIRED"}
-                    results.append(res); progress_cb and progress_cb(res)
+                    results.append(res)
+                    progress_cb and progress_cb(res)
                     saved = True
                     break
 
@@ -277,7 +282,8 @@ def bulk_onboarding(
                         if removed:
                             note += " — removed from accounts.txt"
                     res = {"login": login, "result": "DELETE", "note": note}
-                    results.append(res); progress_cb and progress_cb(res)
+                    results.append(res)
+                    progress_cb and progress_cb(res)
                     saved = True
                     break
 
@@ -285,7 +291,8 @@ def bulk_onboarding(
 
             if not saved:
                 res = {"login": login, "result": "FAILED", "note": last_err or "Пер-аккаунт таймаут"}
-                results.append(res); progress_cb and progress_cb(res)
+                results.append(res)
+                progress_cb and progress_cb(res)
 
         try: context.close()
         except Exception: pass

--- a/src/twitch_api.py
+++ b/src/twitch_api.py
@@ -8,7 +8,9 @@ GQL = URL("https://gql.twitch.tv/gql")
 
 class TwitchAPI:
     def __init__(self, auth_token: str, client_id: str = "kimne78kx3ncx6brgo4mv6wki5h1ko", proxy: str = ""):
-        self.auth = auth_token; self.client_id = client_id; self.proxy = proxy or None
+        self.auth = auth_token
+        self.client_id = client_id
+        self.proxy = proxy or None
         self.session: Optional[aiohttp.ClientSession] = None
         self.ops = load_ops()
         self.ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
@@ -36,7 +38,9 @@ class TwitchAPI:
                     "Content-Type": "application/json",
                 }) as r:
                     if r.status == 429:
-                        await asyncio.sleep(min(60, 2**attempt)); attempt += 1; continue
+                        await asyncio.sleep(min(60, 2**attempt))
+                        attempt += 1
+                        continue
                     if 200 <= r.status < 300:
                         data = await r.json()
                         if isinstance(data, list): data = data[0]
@@ -46,8 +50,10 @@ class TwitchAPI:
                     text = await r.text()
                     raise RuntimeError(f"GQL {r.status}: {text}")
             except aiohttp.ClientError:
-                await asyncio.sleep(min(60, 2**attempt)); attempt += 1
-                if attempt > 5: raise
+                await asyncio.sleep(min(60, 2**attempt))
+                attempt += 1
+                if attempt > 5:
+                    raise
 
     async def viewer_dashboard(self) -> Any: return await self.gql("ViewerDropsDashboard", {})
     async def inventory(self) -> Any: return await self.gql("Inventory", {})


### PR DESCRIPTION
## Summary
- split semicolon-separated statements in accounts, main, GUI, Twitch API, and onboarding modules into distinct lines with proper indentation
- improve readability of control flow and initialization logic while preserving behavior

## Testing
- `python -m py_compile src/accounts.py src/main.py src/gui.py src/twitch_api.py src/onboarding.py`
- `pip install pycodestyle` *(fails: Could not find a version that satisfies the requirement pycodestyle)*

------
https://chatgpt.com/codex/tasks/task_e_689d67e25388832394a84cff1062a59f