### PR TITLE
Handle errors when loading ops

### DIFF
--- a/src/ops.py
+++ b/src/ops.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 import json
+import logging
 from typing import Dict
 from pathlib import Path
 
 OPS_PATH = Path("ops/ops.json")
 REQUIRED = ["ViewerDropsDashboard","Inventory","IncrementDropCurrentSessionProgress","ClaimDropReward"]
 
-def load_ops() -> Dict[str,str]:
-    return json.loads(OPS_PATH.read_text(encoding="utf-8"))
+logger = logging.getLogger(__name__)
+
+
+def load_ops() -> Dict[str, str]:
+    try:
+        return json.loads(OPS_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        logger.error("OPS file not found at %s", OPS_PATH)
+        return {}
+    except json.JSONDecodeError as exc:
+        logger.error("Failed to decode OPS file %s: %s", OPS_PATH, exc)
+        return {}
 
 def missing_ops(ops: dict) -> list[str]:
     miss = []


### PR DESCRIPTION
## Summary
- gracefully load ops.json, returning empty dict on FileNotFoundError
- log and return empty dict on JSON decode issues

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d67f7a160832381cee5013c0a16fd