### PR TITLE
Handle JSON errors when loading auth token

### DIFF
--- a/src/accounts.py
+++ b/src/accounts.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 from pathlib import Path
 from typing import List, Optional
-import csv, json
+import csv, json, logging
 from .types import Account
 
 COOKIES_DIR = Path("cookies"); COOKIES_DIR.mkdir(exist_ok=True)
+logger = logging.getLogger(__name__)
 
 def _parse_txt(path: Path) -> list[Account]:
     res: list[Account] = []
@@ -48,6 +49,7 @@ def auth_token_from_cookies(login: str) -> Optional[str]:
         for c in cookies:
             if c.get("name") == "auth-token":
                 return c.get("value")
-    except Exception:
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        logger.error("Failed to load auth token for %s: %s", login, e)
         return None
     return None

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -1,0 +1,24 @@
+import json
+import logging
+import pytest
+import src.accounts as accounts
+
+
+def test_auth_token_from_cookies_success(tmp_path, monkeypatch):
+    monkeypatch.setattr(accounts, "COOKIES_DIR", tmp_path)
+    token = "abc"
+    (tmp_path / "user.json").write_text(json.dumps([{ "name": "auth-token", "value": token }]), encoding="utf-8")
+    assert accounts.auth_token_from_cookies("user") == token
+
+
+def test_auth_token_from_cookies_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(accounts, "COOKIES_DIR", tmp_path)
+    assert accounts.auth_token_from_cookies("user") is None
+
+
+def test_auth_token_from_cookies_invalid_json(tmp_path, monkeypatch, caplog):
+    monkeypatch.setattr(accounts, "COOKIES_DIR", tmp_path)
+    (tmp_path / "user.json").write_text("{", encoding="utf-8")
+    with caplog.at_level(logging.ERROR):
+        assert accounts.auth_token_from_cookies("user") is None
+        assert "Failed to load auth token" in caplog.text


### PR DESCRIPTION
## Summary
- avoid broad exception handling when reading cookies
- log specific errors and test for auth token cookie parsing

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d67fbcf3c8323816ee24552472e0d