### PR TITLE
refactor miner auth read to thread

### DIFF
--- a/src/miner.py
+++ b/src/miner.py
@@ -16,7 +16,7 @@ PQ = {
     "ViewerDropsDashboard": "30ae6031cdfe0ea3f96a26caf96095a5336b7ccd4e0e7fe9bb2ff1b4cc7efabc",
 }
 
-async def _read_auth_token(cookies_dir: Path, login: str) -> Optional[str]:
+def _read_auth_token(cookies_dir: Path, login: str) -> Optional[str]:
     fp = cookies_dir / f"{login}.json"
     if not fp.exists():
         return None
@@ -54,7 +54,7 @@ async def run_account(login: str, proxy: Optional[str], queue, stop_evt: asyncio
     - обновляет GUI: Status/Campaign/Game
     """
     cookies_dir = Path("cookies")
-    token = await _read_auth_token(cookies_dir, login)
+    token = await asyncio.to_thread(_read_auth_token, cookies_dir, login)
     if not token:
         await queue.put((login, "error", {"msg": "no cookies/auth-token"}))
         return


### PR DESCRIPTION
## Summary
- read auth token files in a thread instead of async pseudo-IO
- update miner worker to use asyncio.to_thread for token loading

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d67fe63b08323987329ada4db2481