### PR TITLE
Check required Twitch GQL ops at startup

### DIFF
--- a/ops/ops.json
+++ b/ops/ops.json
@@ -1,5 +1,5 @@
 {
-  "ViewerDropsDashboard": "actual_hash_from_browser_devtools",
+  "ViewerDropsDashboard": "30ae6031cdfe0ea3f96a26caf96095a5336b7ccd4e0e7fe9bb2ff1b4cc7efabc",
   "Inventory": "actual_hash_from_browser_devtools",
   "IncrementDropCurrentSessionProgress": "actual_hash_from_browser_devtools",
   "ClaimDropReward": "actual_hash_from_browser_devtools"

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,12 @@ def main():
     if args.create_sample_csv: create_sample_csv(Path("accounts.csv")); return
     if not args.accounts: print("Укажите --accounts путь (CSV или TXT)"); sys.exit(2)
 
+    from .ops import load_ops, missing_ops
+    miss = missing_ops(load_ops())
+    if miss:
+        print("Отсутствуют GQL операции в ops/ops.json: " + ", ".join(miss))
+        sys.exit(1)
+
     app = QApplication(sys.argv)
     win = MainWindow(Path(args.accounts))
     win.show()


### PR DESCRIPTION
## Summary
- add known persisted query hash for ViewerDropsDashboard
- ensure the app refuses to start when required GQL operation hashes are missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f389b383c83239eea5ba2c3904a6f