### PR TITLE
Add proxy support across API and onboarding

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -164,7 +164,7 @@ class MainWindow(QMainWindow):
             self._remove_account_from_ui(login)
 
     def onboarding(self):
-        rows = [(a.login, a.password or "", a.totp_secret or "") for a in self.accounts]
+        rows = [(a.login, a.password or "", a.totp_secret or "", a.proxy or "") for a in self.accounts]
         self.log_line(f"Onboarding: запускаю, всего аккаунтов: {len(rows)}")
         bulk_onboarding(
             rows,
@@ -175,7 +175,7 @@ class MainWindow(QMainWindow):
         )
 
     def onboarding_webview(self):
-        accs = [WVAccount(label=a.label, login=a.login, password=a.password or "") for a in self.accounts]
+        accs = [WVAccount(label=a.label, login=a.login, password=a.password or "", proxy=a.proxy or "") for a in self.accounts]
         dlg = WebOnboarding(cookies_dir=Path("cookies"), accounts=accs, per_acc_timeout_sec=120, parent=self)
         dlg.exec()
         self.log_line("Onboarding (WebView) завершён; cookies сохранены.")

--- a/src/miner.py
+++ b/src/miner.py
@@ -67,7 +67,7 @@ async def run_account(login: str, proxy: Optional[str], queue, stop_evt: asyncio
         "Referer": "https://www.twitch.tv/",
     }
 
-    async with aiohttp.ClientSession(headers=headers) as session:
+    async with aiohttp.ClientSession(headers=headers, proxy=proxy or None) as session:
         await queue.put((login, "status", {"status": "Querying", "note": "Fetching campaigns"}))
         try:
             data = await _discover_campaign(session)
@@ -115,5 +115,7 @@ async def run_account(login: str, proxy: Optional[str], queue, stop_evt: asyncio
 
             await queue.put((login, "status", {"status": "Stopped"}))
 
+        except aiohttp.ClientProxyConnectionError as e:
+            await queue.put((login, "error", {"msg": f"Proxy error: {e}"}))
         except Exception as e:
             await queue.put((login, "error", {"msg": f"GQL error: {e}"}))

--- a/src/twitch_api.py
+++ b/src/twitch_api.py
@@ -15,7 +15,7 @@ class TwitchAPI:
 
     async def start(self):
         if not self.session or self.session.closed:
-            self.session = aiohttp.ClientSession(headers={"User-Agent": self.ua})
+            self.session = aiohttp.ClientSession(headers={"User-Agent": self.ua}, proxy=self.proxy)
 
     async def close(self):
         if self.session and not self.session.closed:


### PR DESCRIPTION
## Summary
- pass account proxy settings to aiohttp sessions and post requests
- use account proxy when launching onboarding browsers
- surface proxy connection errors to the GUI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f389d6ae88323a32e8c82b586032b