### PR TITLE
chore: remove duplicate aiohttp requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ aiohttp>=3.9.0
 yarl>=1.9.4
 pyotp>=2.9.0
 playwright>=1.45.0
-aiohttp>=3.9


### PR DESCRIPTION
## Summary
- remove duplicated `aiohttp` entry in requirements
- add missing newline at end of requirements file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689f38a0f4b48323806a1a3e23b03e2b