### PR TITLE
Include DropsCampaignDetails in required ops and test missing hash detection

### DIFF
--- a/src/ops.py
+++ b/src/ops.py
@@ -5,7 +5,13 @@ from typing import Dict
 from pathlib import Path
 
 OPS_PATH = Path("ops/ops.json")
-REQUIRED = ["ViewerDropsDashboard","Inventory","IncrementDropCurrentSessionProgress","ClaimDropReward"]
+REQUIRED = [
+    "ViewerDropsDashboard",
+    "Inventory",
+    "IncrementDropCurrentSessionProgress",
+    "ClaimDropReward",
+    "DropsCampaignDetails",
+]
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -1,0 +1,18 @@
+import json
+import src.ops as ops
+
+
+def test_missing_ops_detects_missing_hash(tmp_path, monkeypatch):
+    # create ops.json without DropsCampaignDetails
+    data = {
+        "ViewerDropsDashboard": "hash",
+        "Inventory": "hash",
+        "IncrementDropCurrentSessionProgress": "hash",
+        "ClaimDropReward": "hash",
+    }
+    path = tmp_path / "ops.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setattr(ops, "OPS_PATH", path)
+
+    loaded = ops.load_ops()
+    assert ops.missing_ops(loaded) == ["DropsCampaignDetails"]


### PR DESCRIPTION
## Summary
- require `DropsCampaignDetails` hash in ops list
- add unit test checking `missing_ops` flags absent hashes
- expand GUI test stubs (Qt widgets, aiohttp) so test suite runs without heavy deps

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e5cdb640832398349c4c2d4729c7