### PR TITLE
Handle colon in password fields when parsing TXT accounts

### DIFF
--- a/src/accounts.py
+++ b/src/accounts.py
@@ -18,7 +18,7 @@ def _parse_txt(path: Path) -> list[Account]:
         line = raw.strip()
         if not line or line.startswith("#"):
             continue
-        parts = line.split(":")
+        parts = line.split(":", 3)
         if len(parts) < 2:
             continue
         login = parts[0].strip()


### PR DESCRIPTION
## Summary
- limit TXT account parsing to the first three colon separators so additional colons stay in the password

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3e7d0b5c083238c26c5535f4e77c0