### PR TITLE
Fetch reward campaigns in viewer dashboard

### DIFF
--- a/src/twitch_api.py
+++ b/src/twitch_api.py
@@ -96,7 +96,7 @@ class TwitchAPI:
 
     async def viewer_dashboard(self) -> Any:
         await self.start()
-        return await self.gql("ViewerDropsDashboard", {})
+        return await self.gql("ViewerDropsDashboard", {"fetchRewardCampaigns": True})
 
     async def inventory(self) -> Any:
         await self.start()

--- a/tests/test_twitch_api.py
+++ b/tests/test_twitch_api.py
@@ -1,0 +1,20 @@
+import asyncio
+from src.twitch_api import TwitchAPI
+
+
+def test_viewer_dashboard_returns_campaigns(monkeypatch):
+    api = TwitchAPI("token")
+
+    async def fake_start():
+        pass
+
+    async def fake_gql(operation, variables):
+        assert operation == "ViewerDropsDashboard"
+        assert variables == {"fetchRewardCampaigns": True}
+        return {"data": {"currentUser": {"dropCampaigns": ["c1"]}}}
+
+    monkeypatch.setattr(api, "start", fake_start)
+    monkeypatch.setattr(api, "gql", fake_gql)
+
+    data = asyncio.run(api.viewer_dashboard())
+    assert data["data"]["currentUser"]["dropCampaigns"] == ["c1"]


### PR DESCRIPTION
## Summary
- ensure ViewerDropsDashboard requests reward campaigns
- add regression test for campaign fetching

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40985e2a08323829762330041dbe4