### PR TITLE
Simplify campaign details call

### DIFF
--- a/src/twitch_api.py
+++ b/src/twitch_api.py
@@ -112,10 +112,7 @@ class TwitchAPI:
 
     async def campaign_details(self, campaign_id: str) -> Any:
         await self.start()
-        try:
-            return await self.gql("DropCampaignDetails", {"campaignID": campaign_id})
-        except RuntimeError:
-            return await self.gql("DropsCampaignDetails", {"campaignID": campaign_id})
+        return await self.gql("DropCampaignDetails", {"campaignID": campaign_id})
 
     async def get_live_channels(self, campaign_id: str) -> list[tuple[str, int, bool]]:
         """


### PR DESCRIPTION
## Summary
- Simplify TwitchAPI.campaign_details to a single `DropCampaignDetails` call handled via get_hash aliasing

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a40c2495c88323bdbeb189f5a89bc1