### PR TITLE
Update required GQL operations and aliases

### DIFF
--- a/src/ops.py
+++ b/src/ops.py
@@ -8,16 +8,17 @@ OPS_PATH = Path("ops/ops.json")
 
 # Алиасы для операций GQL: ключ и его взаимозаменяемый вариант.
 ALIASES = {
-    "DropCampaignDetails": "DropsCampaignDetails",
+    "IncrementDropCurrentSessionProgress": "DropCurrentSessionContext",
+    "ClaimDropReward": "DropsPage_ClaimDropRewards",
     "DropsCampaignDetails": "DropCampaignDetails",
 }
 
 REQUIRED = [
     "ViewerDropsDashboard",
+    "DropCampaignDetails",
     "Inventory",
     "DropCurrentSessionContext",
     "DropsPage_ClaimDropRewards",
-    "DropsCampaignDetails",
 ]
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- replace required GQL operation names with updated set
- map legacy operation names to new ones
- test alias resolution and missing hash detection for all required ops

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a45287357483238c2e780168997d53