### PR TITLE
Retry GQL on server errors

### DIFF
--- a/src/twitch_api.py
+++ b/src/twitch_api.py
@@ -70,7 +70,18 @@ class TwitchAPI:
                     if r.status == 429:
                         attempt += 1
                         if attempt > MAX_RETRIES:
-                            raise RuntimeError("GQL 429: Too Many Requests; retry limit exceeded")
+                            raise RuntimeError(
+                                "GQL 429: Too Many Requests; retry limit exceeded"
+                            )
+                        await asyncio.sleep(min(60, 2 ** (attempt - 1)))
+                        continue
+
+                    if 500 <= r.status < 600:
+                        attempt += 1
+                        if attempt > MAX_RETRIES:
+                            raise RuntimeError(
+                                f"GQL {r.status}: Server error; retry limit exceeded"
+                            )
                         await asyncio.sleep(min(60, 2 ** (attempt - 1)))
                         continue
 


### PR DESCRIPTION
## Summary
- retry Twitch GQL requests when server responds with 5xx status codes
- preserve existing retry logic for rate limits and network errors

## Testing
- `PYTHONPATH=. pytest tests/test_twitch_api.py::test_viewer_dashboard_returns_campaigns -q` *(fails: ModuleNotFoundError: No module named 'aiohttp')*


------
https://chatgpt.com/codex/tasks/task_e_68a477d656948323ba39f4a79f6a4eda