### PR TITLE
Handle integrity challenge with automatic token refresh

### DIFF
--- a/scripts/update_ci.py
+++ b/scripts/update_ci.py
@@ -5,49 +5,20 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+import asyncio
 
-from playwright.sync_api import sync_playwright
-
-from src.accounts import load_accounts, COOKIES_DIR, CI_DIR
-
-
-DROPS_URL = "https://www.twitch.tv/drops"
-GQL_URL = "https://gql.twitch.tv/gql"
+from src.accounts import load_accounts
+from src.client_integrity import fetch_ci, save_ci
 
 
-def fetch_ci(login: str, proxy: str = "") -> tuple[str, str]:
-    """Open Drops page and capture Client-Version and Client-Integrity headers."""
-    cookies_file = COOKIES_DIR / f"{login}.json"
-    if not cookies_file.exists():
-        print(f"No cookies for {login}, skip")
-        return "", ""
-
-    cookies = json.loads(cookies_file.read_text(encoding="utf-8"))
-
-    with sync_playwright() as pw:
-        launch_kwargs = {"headless": True}
-        if proxy:
-            launch_kwargs["proxy"] = {"server": proxy}
-        browser = pw.chromium.launch(**launch_kwargs)
-        context = browser.new_context()
-        context.add_cookies(cookies)
-        page = context.new_page()
-        with page.expect_request(GQL_URL) as req_info:
-            page.goto(DROPS_URL)
-        req = req_info.value
-        headers = req.headers
-        browser.close()
-
-    cv = headers.get("client-version", "")
-    ci = headers.get("client-integrity", "")
-    return cv, ci
-
-
-def save_ci(login: str, cv: str, ci: str) -> None:
-    CI_DIR.mkdir(parents=True, exist_ok=True)
-    path = CI_DIR / f"{login}.json"
-    data = {"client_version": cv, "client_integrity": ci}
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+async def _process(accounts):
+    for acc in accounts:
+        cv, ci = await fetch_ci(acc.login, acc.proxy)
+        if cv and ci:
+            save_ci(acc.login, cv, ci)
+            print(f"{acc.login}: Client-Version={cv} Client-Integrity={ci}")
+        else:
+            print(f"{acc.login}: failed to capture headers")
 
 
 def main() -> None:
@@ -56,13 +27,7 @@ def main() -> None:
     args = ap.parse_args()
 
     accounts = load_accounts(Path(args.accounts))
-    for acc in accounts:
-        cv, ci = fetch_ci(acc.login, acc.proxy)
-        if cv and ci:
-            save_ci(acc.login, cv, ci)
-            print(f"{acc.login}: Client-Version={cv} Client-Integrity={ci}")
-        else:
-            print(f"{acc.login}: failed to capture headers")
+    asyncio.run(_process(accounts))
 
 
 if __name__ == "__main__":

--- a/src/client_integrity.py
+++ b/src/client_integrity.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from pathlib import Path
+from typing import Tuple
+
+# Directories for cookies and client integrity tokens
+COOKIES_DIR = Path("cookies")
+COOKIES_DIR.mkdir(parents=True, exist_ok=True)
+CI_DIR = Path("ci")
+CI_DIR.mkdir(parents=True, exist_ok=True)
+
+DROPS_URL = "https://www.twitch.tv/drops"
+GQL_URL = "https://gql.twitch.tv/gql"
+# Default time-to-live for stored tokens (24h)
+CI_TTL = 60 * 60 * 24
+
+async def fetch_ci(login: str, proxy: str = "") -> Tuple[str, str]:
+    """Open Drops page in headless browser and capture CI headers.
+
+    Returns tuple (Client-Version, Client-Integrity). If cookies for login are
+    missing or headers cannot be captured, returns empty strings.
+    """
+    cookies_file = COOKIES_DIR / f"{login}.json"
+    if not cookies_file.exists():
+        return "", ""
+    try:
+        cookies = json.loads(cookies_file.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return "", ""
+
+    # Import playwright lazily so tests without the dependency still work
+    from playwright.async_api import async_playwright
+
+    async with async_playwright() as pw:
+        launch_kwargs = {"headless": True}
+        if proxy:
+            launch_kwargs["proxy"] = {"server": proxy}
+        browser = await pw.chromium.launch(**launch_kwargs)
+        context = await browser.new_context()
+        await context.add_cookies(cookies)
+        page = await context.new_page()
+
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+
+        def handle_request(req):
+            if req.url == GQL_URL and not fut.done():
+                fut.set_result(req.headers)
+
+        page.on("request", handle_request)
+        await page.goto(DROPS_URL)
+        headers = await fut
+        await browser.close()
+
+    cv = headers.get("client-version", "")
+    ci = headers.get("client-integrity", "")
+    return cv, ci
+
+
+def save_ci(login: str, cv: str, ci: str, ttl: int = CI_TTL) -> None:
+    """Persist tokens for account with expiration timestamp."""
+    data = {
+        "client_version": cv,
+        "client_integrity": ci,
+        "expires_at": time.time() + ttl,
+    }
+    path = CI_DIR / f"{login}.json"
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def load_ci(login: str) -> Tuple[str, str]:
+    """Load tokens for account if not expired."""
+    path = CI_DIR / f"{login}.json"
+    if not path.exists():
+        return "", ""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return "", ""
+    expires = float(data.get("expires_at") or 0)
+    if expires and expires < time.time():
+        return "", ""
+    cv = (
+        data.get("client_version")
+        or data.get("Client-Version")
+        or data.get("clientVersion")
+        or data.get("client-version")
+        or ""
+    )
+    ci = (
+        data.get("client_integrity")
+        or data.get("Client-Integrity")
+        or data.get("clientIntegrity")
+        or data.get("client-integrity")
+        or ""
+    )
+    return str(cv), str(ci)

--- a/src/miner.py
+++ b/src/miner.py
@@ -141,6 +141,7 @@ async def run_account(
         proxy=proxy or "",
         client_version=client_version or "",
         client_integrity=client_integrity or "",
+        login=login,
     )
     await api.start()
     await _safe_put(queue, (login, "status", {"status": "Querying", "note": "Fetching campaigns"}))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path for 'import src'
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add client_integrity module to capture and store Client-Version/Client-Integrity
- refresh CI tokens on integrity challenge and persist per account
- update update_ci script and miner to use new CI management

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68545b5c08323813c321a95822ac7