### PR TITLE
Add persistent session identifiers for Twitch requests

### DIFF
--- a/tests/test_twitch_api.py
+++ b/tests/test_twitch_api.py
@@ -64,6 +64,40 @@ def test_headers_include_ci_tokens(monkeypatch):
     asyncio.run(api.viewer_dashboard())
     assert captured.get("Client-Version") == "cv"
     assert captured.get("Client-Integrity") == "ci"
+    assert captured.get("X-Device-Id") == api.x_device_id
+    assert captured.get("Client-Session-Id") == api.client_session_id
+    assert captured.get("Playback-Session-Id") == api.playback_session_id
+
+
+def test_spade_includes_session_ids(monkeypatch):
+    captured = {}
+    api = TwitchAPI("token")
+
+    class DummyResp:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    async def fake_start():
+        class DummySession:
+            closed = False
+
+            def get(self, url, proxy=None):
+                captured["url"] = str(url)
+                return DummyResp()
+
+        api.session = DummySession()
+
+    monkeypatch.setattr(api, "start", fake_start)
+
+    asyncio.run(api.spade_minute_watched("http://spade.test/event"))
+    u = twitch_api.URL(captured["url"])
+    q = dict(u.query)
+    assert q.get("X-Device-Id") == api.x_device_id
+    assert q.get("Client-Session-Id") == api.client_session_id
+    assert q.get("Playback-Session-Id") == api.playback_session_id
 
 
 def test_challenge_refreshes_tokens(monkeypatch):


### PR DESCRIPTION
## Summary
- generate X-Device-Id, Client-Session-Id, and Playback-Session-Id for each API instance
- send these identifiers with every GQL request and SPADE event
- cover session identifier propagation with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a693a8679083238dd9fe0b64a81248